### PR TITLE
Fix learning rate override for optimizer and scheduler

### DIFF
--- a/nue/train/tokenizer.py
+++ b/nue/train/tokenizer.py
@@ -16,12 +16,12 @@ from sentencepiece import SentencePieceProcessor
 
 from nue.common import BUILD_DIR
 
-# グローバルにロードしておくと子プロセスが継承できる
+# Put global tokenizer to make child process inherit
 TOKENIZER = SentencePieceProcessor()
 TOKENIZER.Load(str(BUILD_DIR / "tokenizer.model"))
 
-PAD_TOKEN_ID: int = TOKENIZER.pad_id()  # 例: 0
-IGNORE_TOKEN_ID = -100  # CrossEntropyLoss が無視する値
+PAD_TOKEN_ID: int = TOKENIZER.pad_id()
+IGNORE_TOKEN_ID = -100
 
 assert PAD_TOKEN_ID is not None
 assert isinstance(PAD_TOKEN_ID, int)

--- a/nue/train/trainer.py
+++ b/nue/train/trainer.py
@@ -299,17 +299,18 @@ class PyTorchTrainer:
                 )
 
         # 学習開始前に学習率を変更する（学習再開時に上書きしたい場合）
-        for i, param_group in enumerate(optimizer.param_groups):
-            param_group["lr"] = options.lr  # オプティマイザの現在の学習率をまず設定
+        if override_base_lr is not None:
+            for param_group in optimizer.param_groups:
+                param_group["lr"] = override_base_lr
 
-        # スケジューラの base_lrs を変更
-        # LambdaLR の場合、base_lrs はリストなので、各要素を変更
-        for j in range(len(scheduler.base_lrs)):
-            scheduler.base_lrs[j] = options.lr
-        click.secho(
-            f"Optimizer and Scheduler base_lrs successfully set to: {options.lr}",
-            fg="cyan",
-        )
+            # スケジューラの base_lrs を変更
+            # LambdaLR の場合、base_lrs はリストなので、各要素を変更
+            for i in range(len(scheduler.base_lrs)):
+                scheduler.base_lrs[i] = override_base_lr
+            click.secho(
+                f"Optimizer and Scheduler base_lrs successfully set to: {override_base_lr}",
+                fg="cyan",
+            )
 
         click.secho("[6/7] Start training loop", fg="green", bold=True)
         model.train()


### PR DESCRIPTION
This PR addresses an issue with overriding the base learning rate for the optimizer and scheduler. The changes ensure that the learning rate is only modified when explicitly specified.

Modified the learning rate override logic in `nue/train/trainer.py`
