### PR TITLE
Refactor trainer classes and remove `Epoch` dataclass

### DIFF
--- a/nue/cli.py
+++ b/nue/cli.py
@@ -19,6 +19,7 @@ from datetime import datetime
 import click
 
 from nue.common import BUILD_DIR
+from nue.train.base import TrainingSession
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
@@ -216,7 +217,7 @@ def train_command(
     override_base_lr: float | None = None,
     framework: str = "torch",
 ):
-    from nue.train import Epoch, TrainingOptions, TrainingSession
+    from nue.train import TrainingOptions
 
     if model_dir is not None:
         click.secho(f"Resuming training from checkpoint {model_dir}", fg="green")
@@ -225,7 +226,6 @@ def train_command(
         with open(os.path.join(model_dir, "train.json"), "r") as f:
             raw_session = json.load(f)
             training_session = TrainingSession(
-                epochs=[Epoch(**e) for e in raw_session["epochs"]],
                 options=TrainingOptions(**raw_session["options"]),
             )
             training_options = training_session.options
@@ -254,7 +254,6 @@ def train_command(
         )
 
         training_session = TrainingSession(
-            epochs=[],
             options=training_options,
         )
         with open(os.path.join(model_dir, "train.json"), "w") as f:
@@ -279,7 +278,6 @@ def train_command(
 
         trainer = PyTorchTrainer(training_options)
         trainer.train(
-            training_session,
             measure_time=measure_time,
             log_validation_max_tokens=log_validation_max_tokens,
             override_base_lr=override_base_lr,
@@ -289,7 +287,6 @@ def train_command(
 
         trainer = MlxTrainer(training_options)
         trainer.train(
-            training_session,
             measure_time=measure_time,
             log_validation_max_tokens=log_validation_max_tokens,
             override_base_lr=override_base_lr,

--- a/nue/mlx/train.py
+++ b/nue/mlx/train.py
@@ -34,12 +34,11 @@ from nue.model.base import GPTConfig
 from nue.train.base import TrainingOptions, TrainingSession
 from nue.train.dataset import load_train_dataset
 from nue.train.tokenizer import IGNORE_TOKEN_ID, PAD_TOKEN_ID, TOKENIZER
+from nue.train.trainer import BaseTrainer
 from nue.utils import format_number_abbrev
 
 
-class MlxTrainer:
-    config: GPTConfig
-    options: TrainingOptions
+class MlxTrainer(BaseTrainer):
     model: NueLM
 
     def __init__(
@@ -47,15 +46,7 @@ class MlxTrainer:
         /,
         options: TrainingOptions,
     ) -> None:
-        self.options = options
-        self.config = GPTConfig(
-            vocab_size=TOKENIZER.vocab_size(),
-            ctx_len=options.ctx_len,
-            n_embed=options.n_embed,
-            n_heads=options.n_heads,
-            n_layers=options.n_layers,
-            mlp_ratio=options.mlp_ratio,
-        )
+        super().__init__(options)
         self.model = NueLM(self.config)
 
     def train(

--- a/nue/mlx/train.py
+++ b/nue/mlx/train.py
@@ -31,7 +31,7 @@ from yaspin import yaspin
 
 from nue.mlx.model import NueLM
 from nue.model.base import GPTConfig
-from nue.train.base import TrainingOptions, TrainingSession
+from nue.train.base import TrainingOptions
 from nue.train.dataset import load_train_dataset
 from nue.train.tokenizer import IGNORE_TOKEN_ID, PAD_TOKEN_ID, TOKENIZER
 from nue.train.trainer import BaseTrainer
@@ -51,7 +51,6 @@ class MlxTrainer(BaseTrainer):
 
     def train(
         self,
-        session: TrainingSession,
         *,
         log_validation_max_tokens: int = 50_000,
         measure_time: bool = False,

--- a/nue/train/__init__.py
+++ b/nue/train/__init__.py
@@ -1,7 +1,8 @@
-from .base import Epoch, TrainingOptions, TrainingSession
+from .base import TrainingOptions, TrainingSession
+from .trainer import BaseTrainer
 
 __all__ = [
-    "Epoch",
+    "BaseTrainer",
     "TrainingOptions",
     "TrainingSession",
 ]

--- a/nue/train/base.py
+++ b/nue/train/base.py
@@ -3,12 +3,6 @@ from typing import Optional
 
 
 @dataclass(frozen=True)
-class Epoch:
-    epoch: int
-    loss: float
-
-
-@dataclass(frozen=True)
 class TrainingOptions:
     n_epochs: int
     batch_size: int
@@ -30,5 +24,4 @@ class TrainingOptions:
 
 @dataclass
 class TrainingSession:
-    epochs: list[Epoch]
     options: TrainingOptions

--- a/nue/train/torch.py
+++ b/nue/train/torch.py
@@ -24,7 +24,6 @@ from typing import Iterable, Optional, cast
 import click
 import torch
 from termcolor import colored
-
 # from torch.amp.grad_scaler import GradScaler
 from torch.nn.utils.rnn import pad_sequence
 from torch.optim import AdamW
@@ -36,6 +35,7 @@ from yaspin.core import Yaspin
 from nue.model.base import GPTConfig
 from nue.model.torch import MinimalGPT, init_weights
 from nue.train.dataset import load_train_dataset
+from nue.train.trainer import BaseTrainer
 from nue.utils import format_number_abbrev
 
 from .base import Epoch, TrainingOptions, TrainingSession
@@ -90,27 +90,18 @@ def collate_pad(batch: list[dict[str, torch.Tensor]]) -> dict[str, torch.Tensor]
     }
 
 
-class PyTorchTrainer:
-    config: GPTConfig
-    options: TrainingOptions
+class PyTorchTrainer(BaseTrainer):
     model: torch.nn.Module | None = None
+    device: torch.device
 
     def __init__(
         self,
         /,
         options: TrainingOptions,
     ) -> None:
-        self.options = options
+        super().__init__(options)
         self.device = detect_device()
 
-        self.config = GPTConfig(
-            vocab_size=TOKENIZER.vocab_size(),
-            ctx_len=options.ctx_len,
-            n_embed=options.n_embed,
-            n_heads=options.n_heads,
-            n_layers=options.n_layers,
-            mlp_ratio=options.mlp_ratio,
-        )
 
     def train(
         self,

--- a/nue/train/torch.py
+++ b/nue/train/torch.py
@@ -24,6 +24,7 @@ from typing import Iterable, Optional, cast
 import click
 import torch
 from termcolor import colored
+
 # from torch.amp.grad_scaler import GradScaler
 from torch.nn.utils.rnn import pad_sequence
 from torch.optim import AdamW
@@ -32,13 +33,12 @@ from torchtune.training import get_cosine_schedule_with_warmup
 from yaspin import yaspin
 from yaspin.core import Yaspin
 
-from nue.model.base import GPTConfig
 from nue.model.torch import MinimalGPT, init_weights
 from nue.train.dataset import load_train_dataset
 from nue.train.trainer import BaseTrainer
 from nue.utils import format_number_abbrev
 
-from .base import Epoch, TrainingOptions, TrainingSession
+from .base import TrainingOptions
 from .tokenizer import IGNORE_TOKEN_ID, PAD_TOKEN_ID, TOKENIZER
 
 # NOTE: torch >= 2.6.0 かつ MPS Backend だと SDPA で NaN が出る
@@ -102,16 +102,14 @@ class PyTorchTrainer(BaseTrainer):
         super().__init__(options)
         self.device = detect_device()
 
-
     def train(
         self,
-        session: TrainingSession,
         *,
         log_validation_max_tokens: int = 50_000,
         measure_time: bool = False,
         override_base_lr: float | None = None,
     ) -> None:
-        options = session.options
+        options = self.options
 
         # シード設定
         if options.seed is not None:
@@ -125,7 +123,7 @@ class PyTorchTrainer(BaseTrainer):
         )
 
         # Save hyperparameters in JSON format
-        with open(os.path.join(session.options.model_dir, "hparams.json"), "w") as f:
+        with open(os.path.join(self.options.model_dir, "hparams.json"), "w") as f:
             json.dump(dataclasses.asdict(self.config), f, indent=4)
 
         # --------- 2) Model 初期化 ---------
@@ -234,7 +232,6 @@ class PyTorchTrainer(BaseTrainer):
         # --------- 5) 前回の学習状態を復元 ---------
         parameters_path = os.path.join(options.model_dir, "parameters.pt")
         checkpoint_path = os.path.join(options.model_dir, "checkpoint.pt")
-        session_path = os.path.join(options.model_dir, "train.json")
 
         checkpoint = None
         start_epoch = 0
@@ -285,12 +282,6 @@ class PyTorchTrainer(BaseTrainer):
                 },
                 checkpoint_path,
             )
-            with open(session_path, "w") as f:
-                json.dump(
-                    dataclasses.asdict(session),
-                    f,
-                    indent=4,
-                )
 
         # 学習開始前に学習率を変更する（学習再開時に上書きしたい場合）
         if override_base_lr is not None:
@@ -552,7 +543,6 @@ class PyTorchTrainer(BaseTrainer):
                     model.train()
 
                 avg_epoch_loss = epoch_loss / len(train_loader)
-                session.epochs.append(Epoch(epoch=i_epoch + 1, loss=avg_epoch_loss))
 
                 spinner.write(
                     colored(
@@ -573,13 +563,6 @@ class PyTorchTrainer(BaseTrainer):
         click.secho(
             f"[7/7] Saving model to {parameters_path}...", fg="bright_green", bold=True
         )
-
-        with open(session_path, "w") as f:
-            json.dump(
-                dataclasses.asdict(session),
-                f,
-                indent=4,
-            )
 
         torch.save(model.state_dict(), parameters_path)
 

--- a/nue/train/trainer.py
+++ b/nue/train/trainer.py
@@ -1,0 +1,22 @@
+from abc import ABC
+
+from nue.model.base import GPTConfig
+
+from .base import TrainingOptions
+from .tokenizer import TOKENIZER
+
+
+class BaseTrainer(ABC):
+    config: GPTConfig
+    options: TrainingOptions
+
+    def __init__(self, options: TrainingOptions):
+        self.options = options
+        self.config = GPTConfig(
+            vocab_size=TOKENIZER.vocab_size(),
+            ctx_len=options.ctx_len,
+            n_embed=options.n_embed,
+            n_heads=options.n_heads,
+            n_layers=options.n_layers,
+            mlp_ratio=options.mlp_ratio,
+        )


### PR DESCRIPTION
This PR refactors the trainer classes and removes the `Epoch` dataclass to simplify the training process and improve code organization.

Main changes:
- Introduced a new `BaseTrainer` abstract class in `nue/train/trainer.py`
- Refactored `PyTorchTrainer` and `MlxTrainer` to inherit from `BaseTrainer`
- Removed `Epoch` dataclass and related functionality
- Updated `TrainingSession` to no longer include `epochs` list
- Modified `train_command` in `cli.py` to reflect these changes

The refactoring aims to reduce code duplication and provide a more consistent structure for different trainer implementations. By removing the `Epoch` dataclass and related logic, we simplify the training process and reduce unnecessary complexity.
