### PR TITLE
Improve MLX performance and add bfloat16 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,23 @@ test:
 train-local:
 	uv run python -m nue.cli train \
 		--batch-size 4 \
-		--lr 3e-4 \
 		--max-warmup-steps 20 \
 		--log-interval 10 \
 		--save-interval 10 \
 		--override-data-size 3% \
-		--log-validation-max-tokens 2048
+		--log-validation-max-tokens 2048 \
+		--measure-time
+
+train-local-mlx:
+	uv run python -m nue.cli train \
+		--framework mlx \
+		--batch-size 4 \
+		--max-warmup-steps 20 \
+		--log-interval 10 \
+		--save-interval 10 \
+		--override-data-size 3% \
+		--log-validation-max-tokens 2048 \
+		--measure-time
 
 train:
 	uv run python -m nue.cli train --batch-size 256

--- a/nue/mlx/model_test.py
+++ b/nue/mlx/model_test.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import mlx.core as mx
+
 from nue.mlx.model import NueLM
 from nue.model.base import GPTConfig
 
@@ -25,6 +27,12 @@ def test_simple():
         mlp_ratio=2,
     )
     m = NueLM(config)
-    assert m
-    # print(m.parameters())
+
     assert len(m.blocks.layers) == config.n_layers
+
+    assert m.ln_f.weight.dtype == mx.float32
+    assert m.ln_f.bias.dtype == mx.float32
+
+    assert m.head.weight.dtype == mx.bfloat16
+
+    assert m.blocks.layers[0].attn.causal.dtype == mx.bfloat16

--- a/nue/mlx/model_test.py
+++ b/nue/mlx/model_test.py
@@ -30,8 +30,8 @@ def test_simple():
 
     assert len(m.blocks.layers) == config.n_layers
 
-    assert m.ln_f.weight.dtype == mx.float32
-    assert m.ln_f.bias.dtype == mx.float32
+    assert m.ln_f.weight.dtype == mx.bfloat16
+    assert m.ln_f.bias.dtype == mx.bfloat16
 
     assert m.head.weight.dtype == mx.bfloat16
 

--- a/nue/mlx/train.py
+++ b/nue/mlx/train.py
@@ -208,7 +208,7 @@ class MlxTrainer(BaseTrainer):
 
                 # NOTE: MLX は遅延計算なので、処理時間を計測するためには結果を eval する必要がある。
                 if measure_time:
-                    mx.eval(loss, grads)
+                    mx.eval(loss)
 
             with iteration.measure_backward():
                 # Update the model with the gradients. So far no computation has happened.

--- a/nue/mlx/train.py
+++ b/nue/mlx/train.py
@@ -344,7 +344,11 @@ def cross_entropy_mean(
     # 各トークンごとの loss 値
     # shape: (B*T,)
     per_token_loss = nn.losses.cross_entropy(
-        logits, safe_labels, label_smoothing=label_smoothing, reduction="none"
+        # NOTE: 損失計算は数値安定性の観点から `float32` で行う
+        logits.astype(mx.float32),
+        safe_labels,
+        label_smoothing=label_smoothing,
+        reduction="none",
     )
 
     # mask で無視する部分を考慮しつつ平均を取る

--- a/nue/model/base.py
+++ b/nue/model/base.py
@@ -9,4 +9,3 @@ class GPTConfig:
     n_heads: int  # number of attention heads
     n_layers: int  # transformer blocks
     mlp_ratio: int  # feed‑forward expansion ratio
-    dropout: float = 0.0

--- a/nue/model/torch.py
+++ b/nue/model/torch.py
@@ -65,7 +65,6 @@ class SelfAttention(nn.Module):
         self.head_dim = cfg.n_embed // cfg.n_heads
         self.qkv = nn.Linear(cfg.n_embed, cfg.n_embed * 3, bias=False)
         self.proj = nn.Linear(cfg.n_embed, cfg.n_embed, bias=False)
-        self.dropout = cfg.dropout
 
         # RoPE precomputed
         self.rotary = RotaryEmbedding(self.head_dim, max_pos=cfg.ctx_len)
@@ -122,7 +121,6 @@ class SelfAttention(nn.Module):
             k,
             v,
             attn_mask=attn_mask,
-            dropout_p=self.dropout if self.training else 0.0,
             is_causal=False,
         )
 


### PR DESCRIPTION
This PR enhances the performance of the MLX framework implementation and adds support for bfloat16 precision. The changes primarily affect the MLX model and training process.

Main components affected:
- `nue/mlx/model.py`
- `nue/mlx/train.py`
- `Makefile`

Key changes:
1. Added bfloat16 support to the `NueLM` model:
   - Set model dtype to `mx.bfloat16`
   - Updated weight initialization to use bfloat16

2. Optimized training process:
   - Implemented `mx.compile` for the training step
   - Removed separate forward and backward measurement steps

3. Updated `Makefile`:
   - Added `train-local-mlx` target for MLX-specific training
   - Added `--measure-time` flag to both local training targets

4. Removed `dropout` parameter from `GPTConfig` and related implementations

These changes aim to improve training speed and memory efficiency while maintaining model accuracy. The use of bfloat16 precision allows for faster computations and reduced memory usage, which is particularly beneficial for large language models.

Note: Some comments in the code suggest that using float32 for certain parameters (LayerNorm weights/biases and Linear biases) might be more stable for training, but bfloat16 was chosen to prioritize memory reduction.