### PR TITLE
Add unit tests for tokenizer chunking

### DIFF
--- a/.windsurf/rules/rules.md
+++ b/.windsurf/rules/rules.md
@@ -1,0 +1,6 @@
+---
+trigger: always_on
+---
+
+- `make check` to run lint, type check and tests.
+- `make test` to run tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+- type check: `uv run pyright ./nue/*.py ./nue/model ./nue/train`
+- lint: `uv run ruff check ./nue/*.py ./nue/model ./nue/train`
+- test: `uv run pytest ./nue/*.py ./nue/model ./nue/train`

--- a/nue/train/dataset.py
+++ b/nue/train/dataset.py
@@ -33,7 +33,7 @@ from nue.datasets import DATASET_LIST
 from .tokenizer import TOKENIZER
 
 
-def __tokenize_and_chunk(
+def _tokenize_and_chunk(
     text: str, tokenizer: SentencePieceProcessor, ctx_len: int, overlap_len: int
 ) -> list[list[int]]:
     """テキストをトークナイズし、オーバーラップ付きのチャンクに分割する"""
@@ -74,7 +74,7 @@ def __tokenize_and_chunk(
 
 
 # --- 第1段階の map で使用する関数 ---
-def __map_tokenize_to_chunk_lists(
+def _map_tokenize_to_chunk_lists(
     examples: dict[str, list], column: str, ctx_len: int, overlap_len: int
 ) -> dict[str, list]:
     """
@@ -84,7 +84,7 @@ def __map_tokenize_to_chunk_lists(
     output = {"input_ids_chunks": [], "num_tokens_chunks": []}
     # TOKENIZER はグローバル変数から参照
     for text in examples[column]:
-        chunks = __tokenize_and_chunk(text, TOKENIZER, ctx_len, overlap_len)
+        chunks = _tokenize_and_chunk(text, TOKENIZER, ctx_len, overlap_len)
         output["input_ids_chunks"].append(chunks)
         output["num_tokens_chunks"].append([len(c) for c in chunks])
     return output
@@ -117,7 +117,7 @@ def load_train_dataset(
 
         # Tokenize
         mapped_dataset = dataset.map(
-            __map_tokenize_to_chunk_lists,
+            _map_tokenize_to_chunk_lists,
             fn_kwargs={
                 "column": dataset_config.content_column,
                 "ctx_len": ctx_len,

--- a/nue/train/dataset_test.py
+++ b/nue/train/dataset_test.py
@@ -1,11 +1,27 @@
-import pytest
+from __future__ import annotations
 
+import numpy as np
+import pytest
+from typing import Any, List, Union
 from nue.train.dataset import _tokenize_and_chunk
 
 
 class DummyTokenizer:
-    def EncodeAsIds(self, text: str) -> list[int]:
-        return list(range(1, len(text) + 1))
+    """テスト用のシンプルなトークナイザー"""
+    def EncodeAsIds(self, input: str, **kwargs: Any) -> List[int]:
+        return list(range(1, len(input) + 1))
+    
+    def EncodeAsPieces(self, input: str, **kwargs: Any) -> List[str]:
+        return list(input)
+    
+    def DecodeIds(self, input: Union[List[int], np.ndarray], out_type: type = str, **kwargs: Any) -> str:
+        if isinstance(input, np.ndarray):
+            input = input.tolist()
+        decoded = ''.join(chr(i + 96) for i in input)
+        return out_type(decoded)
+    
+    def GetPieceSize(self) -> int:
+        return 10000
 
 
 def test_short_text_returns_single_chunk():

--- a/nue/train/dataset_test.py
+++ b/nue/train/dataset_test.py
@@ -1,0 +1,32 @@
+import pytest
+
+from nue.train.dataset import _tokenize_and_chunk
+
+
+class DummyTokenizer:
+    def EncodeAsIds(self, text: str) -> list[int]:
+        return list(range(1, len(text) + 1))
+
+
+def test_short_text_returns_single_chunk():
+    tokenizer = DummyTokenizer()
+    result = _tokenize_and_chunk("abc", tokenizer, ctx_len=5, overlap_len=1)
+    assert result == [[1, 2, 3]]
+
+
+def test_overlapping_chunks_are_created_correctly():
+    tokenizer = DummyTokenizer()
+    text = "abcdefghij"
+    result = _tokenize_and_chunk(text, tokenizer, ctx_len=4, overlap_len=1)
+    assert result == [
+        [1, 2, 3, 4],
+        [4, 5, 6, 7],
+        [7, 8, 9, 10],
+        [10],
+    ]
+
+
+def test_invalid_overlap_raises_value_error():
+    tokenizer = DummyTokenizer()
+    with pytest.raises(ValueError):
+        _tokenize_and_chunk("abcdef", tokenizer, ctx_len=4, overlap_len=4)


### PR DESCRIPTION
## Summary
- rename `__tokenize_and_chunk` and `__map_tokenize_to_chunk_lists`
- update dataset tests to use the new helper names

## Testing
- `ruff format ./nue`
- `ruff check ./nue`
- `pyright` *(fails: Import errors)*
- `python3 -m pytest -q` *(fails: No module named pytest)*