### PR TITLE
Add missing module docstrings

### DIFF
--- a/nue/__init__.py
+++ b/nue/__init__.py
@@ -1,0 +1,2 @@
+
+"""Nue library root package."""

--- a/nue/cli.py
+++ b/nue/cli.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Command line interface for common training utilities."""
+
 import dataclasses
 import json
 import os

--- a/nue/common.py
+++ b/nue/common.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Paths and utilities shared across the package."""
+
 import pathlib
 
 BUILD_DIR = pathlib.Path(__file__).parent.parent / "build"

--- a/nue/datasets.py
+++ b/nue/datasets.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Configuration helpers for dataset loading."""
+
 from dataclasses import dataclass
 from typing import Literal, Optional
 

--- a/nue/mlx/__init__.py
+++ b/nue/mlx/__init__.py
@@ -1,0 +1,1 @@
+"""MXNet-like training implementation using mlx."""

--- a/nue/mlx/model.py
+++ b/nue/mlx/model.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Minimal GPT model implemented with mlx."""
+
 import math
 from typing import cast
 

--- a/nue/mlx/model_test.py
+++ b/nue/mlx/model_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Tests for mlx GPT model implementation."""
+
 import mlx.core as mx
 
 from nue.mlx.model import NueLM

--- a/nue/mlx/train.py
+++ b/nue/mlx/train.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Training utilities built on top of mlx."""
+
 import json
 import math
 import os

--- a/nue/model/__init__.py
+++ b/nue/model/__init__.py
@@ -1,3 +1,5 @@
+"""Model initialization utilities and re-exports."""
+
 from .base import GPTConfig
 
 __all__ = [

--- a/nue/model/base.py
+++ b/nue/model/base.py
@@ -1,3 +1,5 @@
+"""Base dataclasses for model configuration."""
+
 from dataclasses import dataclass
 
 

--- a/nue/model/torch.py
+++ b/nue/model/torch.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Minimal GPT model implementation using PyTorch."""
+
 from typing import cast
 
 import torch

--- a/nue/model/torch_test.py
+++ b/nue/model/torch_test.py
@@ -1,3 +1,5 @@
+"""Tests for the PyTorch GPT model."""
+
 import torch
 
 from .base import GPTConfig

--- a/nue/train/__init__.py
+++ b/nue/train/__init__.py
@@ -1,3 +1,5 @@
+"""Training utilities and session helpers."""
+
 from .base import TrainingOptions, TrainingSession
 from .trainer import BaseTrainer
 

--- a/nue/train/base.py
+++ b/nue/train/base.py
@@ -1,3 +1,5 @@
+"""Base dataclasses used by the training pipeline."""
+
 from dataclasses import dataclass
 from typing import Optional
 

--- a/nue/train/dataset.py
+++ b/nue/train/dataset.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Helpers for tokenizing and chunking training datasets."""
+
 import os
 import re
 from typing import Any, List, Optional, Protocol, Union, cast

--- a/nue/train/dataset_test.py
+++ b/nue/train/dataset_test.py
@@ -1,3 +1,5 @@
+"""Tests for dataset tokenization utilities."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/nue/train/tokenizer.py
+++ b/nue/train/tokenizer.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Global tokenizer instance used across training workers."""
+
 from sentencepiece import SentencePieceProcessor
 
 from nue.common import BUILD_DIR

--- a/nue/train/torch.py
+++ b/nue/train/torch.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Training loop implementation using PyTorch."""
+
 import math
 import os
 import platform

--- a/nue/train/trainer.py
+++ b/nue/train/trainer.py
@@ -1,3 +1,5 @@
+"""Abstract trainer and helpers for managing training loops."""
+
 import dataclasses
 import json
 import math

--- a/nue/utils.py
+++ b/nue/utils.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Utility helpers for formatting and other small tasks."""
+
+
 
 def format_number_abbrev(n: int) -> str:
     """

--- a/nue/utils_test.py
+++ b/nue/utils_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Unit tests for small helper functions."""
+
 from .utils import format_number_abbrev
 
 


### PR DESCRIPTION
## Summary
- add module docstrings across library

## Testing
- `uv run ruff check ./nue/*.py ./nue/model ./nue/train`
- `uv run pyright ./nue/*.py ./nue/model ./nue/train`
- `uv run pytest ./nue/*.py ./nue/model ./nue/train`