### PR TITLE
Add LR override in mlx trainer

### DIFF
--- a/.windsurf/rules/rules.md
+++ b/.windsurf/rules/rules.md
@@ -2,5 +2,6 @@
 trigger: always_on
 ---
 
+- `make format` to format code
 - `make check` to run lint, type check and tests.
 - `make test` to run tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,4 @@
+- format: `make format`
 - type check: `uv run pyright ./nue/*.py ./nue/model ./nue/train`
 - lint: `uv run ruff check ./nue/*.py ./nue/model ./nue/train`
 - test: `uv run pytest ./nue/*.py ./nue/model ./nue/train`

--- a/nue/__init__.py
+++ b/nue/__init__.py
@@ -1,2 +1,1 @@
-
 """Nue library root package."""

--- a/nue/mlx/train.py
+++ b/nue/mlx/train.py
@@ -21,6 +21,8 @@ import random
 from functools import partial
 from typing import Any, Callable, Iterator, Optional, cast
 
+import click
+
 import mlx.core as mx
 import mlx.data
 import mlx.nn as nn
@@ -169,6 +171,13 @@ class MlxTrainer(BaseTrainer):
         measure_time: bool,
         override_base_lr: float | None,
     ) -> None:
+        """Run the training loop.
+
+        If ``override_base_lr`` is provided, the optimizer's learning rate is
+        set to the given value before the loop starts. This mirrors the
+        ``PyTorchTrainer`` behaviour where the optimizer's current learning
+        rate is overwritten when resuming training.
+        """
         assert self.model is not None
         assert self.train_dataset is not None
         assert self.validation_dataset is not None
@@ -178,7 +187,13 @@ class MlxTrainer(BaseTrainer):
 
         optimizer = self.optimizer
 
-        # TODO: 学習開始前に学習率を変更する（学習再開時に上書きしたい場合）
+        # 学習開始前に学習率を変更する（学習再開時に上書きしたい場合）
+        if override_base_lr is not None:
+            optimizer.learning_rate = override_base_lr
+            click.secho(
+                f"Optimizer learning rate successfully set to: {override_base_lr}",
+                fg="cyan",
+            )
 
         def loss_fn(
             model: nn.Module,

--- a/nue/mlx/train_test.py
+++ b/nue/mlx/train_test.py
@@ -1,11 +1,9 @@
 import pytest
-
-mx = pytest.importorskip("mlx.core")
-
 from datasets import Dataset
-
 from nue.mlx.train import MlxTrainer
 from nue.train.base import TrainingOptions
+
+mx = pytest.importorskip("mlx.core")
 
 
 class DummyTrainer(MlxTrainer):
@@ -56,4 +54,3 @@ def test_override_base_lr(tmp_path):
     )
 
     assert pytest.approx(trainer.learning_rate, rel=1e-6) == 0.2
-

--- a/nue/mlx/train_test.py
+++ b/nue/mlx/train_test.py
@@ -1,0 +1,59 @@
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from datasets import Dataset
+
+from nue.mlx.train import MlxTrainer
+from nue.train.base import TrainingOptions
+
+
+class DummyTrainer(MlxTrainer):
+    def train_loop(
+        self,
+        *,
+        log_validation_max_tokens: int,
+        measure_time: bool = False,
+    ):
+        if False:
+            yield
+
+
+def _make_options(tmp_path: str) -> TrainingOptions:
+    return TrainingOptions(
+        n_epochs=1,
+        batch_size=1,
+        ctx_len=4,
+        chunk_overlap_len=0,
+        n_embed=4,
+        n_heads=2,
+        n_layers=1,
+        mlp_ratio=2,
+        seed=0,
+        lr=0.01,
+        max_warmup_steps=1,
+        log_interval=1,
+        save_interval=1,
+        model_dir=tmp_path,
+        framework="mlx",
+    )
+
+
+def test_override_base_lr(tmp_path):
+    opts = _make_options(str(tmp_path))
+    trainer = DummyTrainer(opts)
+
+    ds = Dataset.from_dict({"input_ids": [[1, 2, 3, 4]]})
+    trainer.train_dataset = ds
+    trainer.validation_dataset = ds
+    trainer.on_load_dataset(ds, ds)
+    trainer.on_train_prepare()
+
+    trainer._train(
+        log_validation_max_tokens=0,
+        measure_time=False,
+        override_base_lr=0.2,
+    )
+
+    assert pytest.approx(trainer.learning_rate, rel=1e-6) == 0.2
+

--- a/nue/train/dataset.py
+++ b/nue/train/dataset.py
@@ -187,5 +187,3 @@ def load_train_dataset(
     final_dataset = final_dataset.remove_columns("num_tokens")
 
     return final_dataset, total_tokens
-
-

--- a/nue/train/dataset_test.py
+++ b/nue/train/dataset_test.py
@@ -10,18 +10,21 @@ from nue.train.dataset import _tokenize_and_chunk
 
 class DummyTokenizer:
     """テスト用のシンプルなトークナイザー"""
+
     def EncodeAsIds(self, input: str, **kwargs: Any) -> List[int]:
         return list(range(1, len(input) + 1))
-    
+
     def EncodeAsPieces(self, input: str, **kwargs: Any) -> List[str]:
         return list(input)
-    
-    def DecodeIds(self, input: Union[List[int], np.ndarray], out_type: type = str, **kwargs: Any) -> str:
+
+    def DecodeIds(
+        self, input: Union[List[int], np.ndarray], out_type: type = str, **kwargs: Any
+    ) -> str:
         if isinstance(input, np.ndarray):
             input = input.tolist()
-        decoded = ''.join(chr(i + 96) for i in input)
+        decoded = "".join(chr(i + 96) for i in input)
         return out_type(decoded)
-    
+
     def GetPieceSize(self) -> int:
         return 10000
 

--- a/nue/utils.py
+++ b/nue/utils.py
@@ -15,7 +15,6 @@
 """Utility helpers for formatting and other small tasks."""
 
 
-
 def format_number_abbrev(n: int) -> str:
     """
     Convert a number to a string with an abbreviation (K, M, B).


### PR DESCRIPTION
## Summary
- allow learning rate override in `nue/mlx/train.MlxTrainer`
- document behaviour and import `click`
- add mlx trainer test for overriding learning rate

## Testing
- `uv run ruff check ./nue/*.py ./nue/model ./nue/train`
- `uv run pyright ./nue/*.py ./nue/model ./nue/train`
- `uv run pytest ./nue/*.py ./nue/model ./nue/train`
