### PR TITLE
Improve time measurement in training process

### DIFF
--- a/nue/train/torch.py
+++ b/nue/train/torch.py
@@ -307,15 +307,14 @@ class PyTorchTrainer(BaseTrainer):
                 dtype=torch.bfloat16,
                 enabled=use_amp,
             ):
-                with iteration.measure_forward():
-                    input_ids = batch["input_ids"].to(self.device)
-                    attention_mask = batch["attention_mask"].to(self.device)
-                    labels = batch["labels"].to(self.device)
+                input_ids = batch["input_ids"].to(self.device)
+                attention_mask = batch["attention_mask"].to(self.device)
+                labels = batch["labels"].to(self.device)
 
-                    logits = model(
-                        input_ids,
-                        attention_mask=attention_mask,
-                    )
+                logits = model(
+                    input_ids,
+                    attention_mask=attention_mask,
+                )
 
                 loss = criterion(
                     logits.view(-1, self.config.vocab_size),
@@ -330,10 +329,9 @@ class PyTorchTrainer(BaseTrainer):
                 logits_mean=logits_mean,
             )
 
-            with iteration.measure_backward():
-                # 勾配の計算
-                # grad_scaler.scale(loss).backward()
-                loss.backward()
+            # 勾配の計算
+            # grad_scaler.scale(loss).backward()
+            loss.backward()
 
             # 勾配のクリッピング
             # ただし、小規模モデルは毎 step でなくても安定する
@@ -342,15 +340,14 @@ class PyTorchTrainer(BaseTrainer):
                 # grad_scaler.unscale_(optimizer)
                 torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
 
-            with iteration.measure_optimizer():
-                # パラメータの更新
-                # grad_scaler.step(optimizer)
-                # grad_scaler.update()
-                optimizer.step()
-                scheduler.step()
+            # パラメータの更新
+            # grad_scaler.step(optimizer)
+            # grad_scaler.update()
+            optimizer.step()
+            scheduler.step()
 
-                # 勾配の初期化
-                optimizer.zero_grad()
+            # 勾配の初期化
+            optimizer.zero_grad()
 
     @torch.no_grad()
     def generate(


### PR DESCRIPTION
This PR simplifies and optimizes the time measurement process during model training. The changes focus on reducing granularity in time measurement while maintaining overall step timing.

Main changes:
1. Removed individual timing measurements for IO, forward pass, backward pass, and optimizer steps in `TrainingIteration` class.
2. Simplified the `PyTorchTrainer` class by removing separate timing contexts for different training phases.
3. Updated the progress logging to only display the total step time instead of breaking it down into individual components.

Reason for changes:
The previous implementation had a more granular approach to time measurement, which may have introduced slight overhead. This simplification aims to reduce any potential impact on training performance while still providing useful timing information for the entire training step.

Implementation details:
- Removed `io_elapsed`, `forward_elapsed`, `backward_elapsed`, and `optimizer_elapsed` attributes from `TrainingIteration`.
- Kept only the `step_elapsed` attribute for overall step timing.
- Removed corresponding `measure_*` methods in `TrainingIteration`.
- Simplified the training loop in `PyTorchTrainer` by removing individual timing contexts.
- Updated progress logging to display only the total step time.

These changes should result in a cleaner, more streamlined timing measurement process during training without losing essential timing information.