### PR TITLE
save optimizer state

### DIFF
--- a/nue/train/torch.py
+++ b/nue/train/torch.py
@@ -192,7 +192,7 @@ class PyTorchTrainer(BaseTrainer):
         )
 
     def on_train_resume(
-        self, checkpoint_path: str
+        self,
     ) -> tuple[
         int,  # epoch
         int,  # step
@@ -201,7 +201,7 @@ class PyTorchTrainer(BaseTrainer):
         assert self.optimizer is not None
         assert self.scheduler is not None
 
-        checkpoint = torch.load(checkpoint_path, map_location=self.device)
+        checkpoint = torch.load(self.checkpoint_path, map_location=self.device)
 
         self.model.load_state_dict(checkpoint["model_state"])
         self.optimizer.load_state_dict(checkpoint["optimizer_state"])

--- a/nue/train/trainer.py
+++ b/nue/train/trainer.py
@@ -181,9 +181,7 @@ class BaseTrainer(ABC):
                 fg="green",
                 bold=True,
             )
-            self.start_epoch, self.start_step = self.on_train_resume(
-                checkpoint_path=self.checkpoint_path
-            )
+            self.start_epoch, self.start_step = self.on_train_resume()
         else:
             click.secho("[5/7] Training from scratch", fg="bright_green", bold=True)
             os.makedirs(self.options.model_dir, exist_ok=True)
@@ -387,7 +385,7 @@ class BaseTrainer(ABC):
 
     @abstractmethod
     def on_train_resume(
-        self, checkpoint_path: str
+        self,
     ) -> tuple[
         int,  # epoch
         int,  # step


### PR DESCRIPTION
This PR improves the checkpoint handling process and adds functionality to save and load optimizer state for both MLX and PyTorch trainers.

Main changes:
1. Modified `MLXTrainer` to save and load optimizer state
2. Updated `PyTorchTrainer` to use `self.checkpoint_path` instead of a parameter
3. Adjusted `BaseTrainer` to remove the `checkpoint_path` parameter from `on_train_resume`

Key implementation details:
- For MLX:
  - Added `tree_flatten` and `tree_unflatten` from `mlx.utils` to handle optimizer state
  - Introduced separate files for model weights, optimizer state, and metadata
  - Used `mx.save_safetensors` and `mx.load` for optimizer state serialization

- For PyTorch:
  - Simplified `on_train_resume` to use `self.checkpoint_path`

- In `BaseTrainer`:
  - Updated the `on_train_resume` method signature to remove the `checkpoint_path` parameter

These changes improve consistency in checkpoint handling across different trainer implementations and ensure that the optimizer state is properly saved and restored during training resumption.